### PR TITLE
Fix/update check v1.3.2 , Lokka 2.1.2 support, and CI release builds (v1.3.2–v1.3.4)

### DIFF
--- a/.github/workflows/beta-release-signed.yml
+++ b/.github/workflows/beta-release-signed.yml
@@ -41,8 +41,38 @@ jobs:
           CI: true
           NODE_OPTIONS: --max-old-space-size=4096
 
-      - name: Build and sign Windows application
-        run: npm run build && npx electron-builder --win --publish=never
+      - name: Build Windows application (signed with unsigned fallback)
+        shell: powershell
+        run: |
+          npm run build
+          if ($LASTEXITCODE -ne 0) { Write-Error "App build (webpack) failed"; exit 1 }
+
+          $signed = $false
+          if (-not [string]::IsNullOrWhiteSpace($env:WIN_CSC_LINK)) {
+            Write-Host "Code-signing certificate provided - attempting SIGNED Windows build..."
+            npx electron-builder --win --publish=never
+            if ($LASTEXITCODE -eq 0) {
+              $signed = $true
+              Write-Host "Signed Windows build succeeded"
+            } else {
+              Write-Host "::warning title=Windows signing failed::Signed build failed (exit $LASTEXITCODE) - the code-signing certificate is likely expired, revoked, or invalid. Falling back to an UNSIGNED build so the release and latest.yml are still produced."
+            }
+          } else {
+            Write-Host "::warning title=No signing cert::WIN_CSC_LINK secret is empty - building Windows UNSIGNED."
+          }
+
+          if (-not $signed) {
+            # Remove signing inputs so electron-builder produces an unsigned build rather than failing
+            Remove-Item Env:WIN_CSC_LINK -ErrorAction SilentlyContinue
+            Remove-Item Env:WIN_CSC_KEY_PASSWORD -ErrorAction SilentlyContinue
+            Remove-Item Env:CSC_LINK -ErrorAction SilentlyContinue
+            Remove-Item Env:CSC_KEY_PASSWORD -ErrorAction SilentlyContinue
+            $env:CSC_IDENTITY_AUTO_DISCOVERY = "false"
+            npx electron-builder --win --publish=never
+            if ($LASTEXITCODE -ne 0) { Write-Error "Unsigned Windows build failed"; exit 1 }
+            Write-Host "Unsigned Windows build succeeded"
+            "## Windows ${{ github.event.inputs.version }} built UNSIGNED (code-signing cert unavailable/expired)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}

--- a/.github/workflows/beta-release-signed.yml
+++ b/.github/workflows/beta-release-signed.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/beta-release-unsigned.yml
+++ b/.github/workflows/beta-release-unsigned.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -70,7 +70,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -102,7 +102,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -210,7 +210,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Clean npm cache

--- a/.github/workflows/beta-release-unsigned.yml
+++ b/.github/workflows/beta-release-unsigned.yml
@@ -54,7 +54,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-unsigned
-          path: dist-release/*.exe
+          # Include latest.yml + .blockmap (not just *.exe) so electron-updater metadata reaches the release
+          path: |
+            dist-release/*.exe
+            dist-release/*.yml
+            dist-release/*.blockmap
 
   build-macos:
     needs: setup
@@ -258,10 +262,16 @@ jobs:
           
       - name: Upload release artifacts
         run: |
-          # Upload all artifacts from dist-release directory
+          # Upload installers plus auto-update metadata (latest.yml + blockmap),
+          # which electron-updater requires to detect updates.
           gh release upload ${{ github.event.inputs.version }} dist-release/*.exe --clobber
+          gh release upload ${{ github.event.inputs.version }} dist-release/*.yml --clobber
+          if (Test-Path "dist-release\*.blockmap") {
+            gh release upload ${{ github.event.inputs.version }} dist-release/*.blockmap --clobber
+          }
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: powershell
           
       - name: Upload build artifacts (on failure)
         if: failure()

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Clean npm cache

--- a/.github/workflows/release-multiplatform-signed.yml
+++ b/.github/workflows/release-multiplatform-signed.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -201,7 +201,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies
@@ -277,7 +277,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release-multiplatform-signed.yml
+++ b/.github/workflows/release-multiplatform-signed.yml
@@ -137,6 +137,21 @@ jobs:
             Write-Host "No Windows executables found in dist-release"
             Get-ChildItem "dist-release" -Recurse | Where-Object { $_.Name -like "*.exe" } | ForEach-Object { Write-Host "Found: $($_.FullName)" }
           }
+          # Upload auto-update metadata (latest.yml + blockmap) required by electron-updater
+          if (Test-Path "dist-release\*.yml") {
+            Write-Host "Found Windows update metadata:"
+            Get-ChildItem "dist-release\*.yml" | ForEach-Object { Write-Host "  $_" }
+            Get-ChildItem "dist-release\*.yml" | ForEach-Object {
+              gh release upload "${{ github.event.inputs.version }}" "$_" --clobber
+            }
+          } else {
+            Write-Host "WARNING: No latest.yml found in dist-release - auto-update will not work"
+          }
+          if (Test-Path "dist-release\*.blockmap") {
+            Get-ChildItem "dist-release\*.blockmap" | ForEach-Object {
+              gh release upload "${{ github.event.inputs.version }}" "$_" --clobber
+            }
+          }
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: powershell
@@ -197,6 +212,22 @@ jobs:
           else
             echo "No macOS ZIP files found in dist-release"
             find dist-release -name "*.zip" -type f
+          fi
+
+          # Upload auto-update metadata (latest-mac.yml + blockmap) required by electron-updater
+          if ls dist-release/*.yml 2>/dev/null; then
+            echo "Found macOS update metadata:"
+            ls -la dist-release/*.yml
+            for file in dist-release/*.yml; do
+              gh release upload "${{ github.event.inputs.version }}" "$file" --clobber
+            done
+          else
+            echo "WARNING: No latest-mac.yml found in dist-release - auto-update will not work"
+          fi
+          if ls dist-release/*.blockmap 2>/dev/null; then
+            for file in dist-release/*.blockmap; do
+              gh release upload "${{ github.event.inputs.version }}" "$file" --clobber
+            done
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -279,6 +310,17 @@ jobs:
           else
             echo "No Linux TAR.GZ files found in dist-release"
             find dist-release -name "*.tar.gz" -type f
+          fi
+
+          # Upload auto-update metadata (latest-linux.yml) required by electron-updater
+          if ls dist-release/*.yml 2>/dev/null; then
+            echo "Found Linux update metadata:"
+            ls -la dist-release/*.yml
+            for file in dist-release/*.yml; do
+              gh release upload "${{ github.event.inputs.version }}" "$file" --clobber
+            done
+          else
+            echo "WARNING: No latest-linux.yml found in dist-release - auto-update will not work"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-multiplatform-signed.yml
+++ b/.github/workflows/release-multiplatform-signed.yml
@@ -118,8 +118,39 @@ jobs:
           CI: true
           NODE_OPTIONS: --max-old-space-size=4096
 
-      - name: Build application (Windows signed)
-        run: npm run build && npx electron-builder --win --publish=never
+      - name: Build application (Windows, signed with unsigned fallback)
+        shell: powershell
+        run: |
+          npm run build
+          if ($LASTEXITCODE -ne 0) { Write-Error "App build (webpack) failed"; exit 1 }
+
+          $signed = $false
+          if (-not [string]::IsNullOrWhiteSpace($env:WIN_CSC_LINK)) {
+            Write-Host "Code-signing certificate provided - attempting SIGNED Windows build..."
+            npx electron-builder --win --publish=never
+            if ($LASTEXITCODE -eq 0) {
+              $signed = $true
+              Write-Host "Signed Windows build succeeded"
+            } else {
+              Write-Host "::warning title=Windows signing failed::Signed build failed (exit $LASTEXITCODE) - the code-signing certificate is likely expired, revoked, or invalid. Falling back to an UNSIGNED build so the release and latest.yml are still produced."
+            }
+          } else {
+            Write-Host "::warning title=No signing cert::WIN_CSC_LINK secret is empty - building Windows UNSIGNED."
+          }
+
+          if (-not $signed) {
+            # Remove signing inputs so electron-builder produces an unsigned build rather than failing
+            Remove-Item Env:WIN_CSC_LINK -ErrorAction SilentlyContinue
+            Remove-Item Env:WIN_CSC_KEY_PASSWORD -ErrorAction SilentlyContinue
+            Remove-Item Env:CSC_LINK -ErrorAction SilentlyContinue
+            Remove-Item Env:CSC_KEY_PASSWORD -ErrorAction SilentlyContinue
+            $env:CSC_IDENTITY_AUTO_DISCOVERY = "false"
+            npx electron-builder --win --publish=never
+            if ($LASTEXITCODE -ne 0) { Write-Error "Unsigned Windows build failed"; exit 1 }
+            Write-Host "Unsigned Windows build succeeded"
+            "## Windows v${{ github.event.inputs.version }} built UNSIGNED" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            "The code-signing certificate was unavailable/expired, so the Windows installer is UNSIGNED. Users may see a SmartScreen warning, and clients already running a signed build may refuse the auto-update signature check. Renew the DigiCert cert, update the WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD secrets, and re-release to restore signed updates." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
     
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to EntraPulse Lite are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - Unreleased
+
+### Added
+- **Two more interactive Lokka MCP apps** exposed inline in chat, bringing
+  the total to six: **Lokka Settings** (umbrella over Connections +
+  Guardrails) and **Guardrails** (user-set policy limiting model-originated
+  Lokka calls; off by default). Open them with, e.g. *"lokka settings"* or
+  *"guardrails"*. Guardrails config is driven over the MCP Apps bridge and
+  allowed by the policy gate; EntraPulse still owns authentication.
+
+### Changed
+- **Lokka MCP upgraded to v2.1.2** (from v2.0.0). Includes the upstream
+  SSRF / token-exfiltration security fix and other stability
+  improvements. Pin updated in `package.json` and `src/mcp/constants.ts`.
+
 ## [1.2.0] - Unreleased
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A free community desktop application that provides natural language querying of 
 - **Real-time LLM Status Monitoring**: Dynamic tracking of LLM availability with automatic UI updates
 - **Automatic Updates**: Seamless updates delivered through GitHub Releases with code signing and user control
 - **Built-in MCP Servers** (Recommended: Enable Both for Best Coverage): 
-  - **Lokka MCP** using the official @merill/lokka package (v2.0.0) - Fast, privacy-first Microsoft Graph and Azure Resource Manager API access for common queries, with **interactive MCP apps** (Graph Explorer, Connections, Permissions, Help) rendered inline in chat
+  - **Lokka MCP** using the official @merill/lokka package (v2.1.2) - Fast, privacy-first Microsoft Graph and Azure Resource Manager API access for common queries, with **interactive MCP apps** (Graph Explorer, Connections, Permissions, Help, Settings, Guardrails) rendered inline in chat
   - **Microsoft Enterprise MCP** (Cloud) - Enterprise features: Audit Logs, PIM, Conditional Access, Device Compliance
   - Microsoft Docs MCP using the official MicrosoftDocs/MCP package for Microsoft Learn documentation and official Microsoft documentation
   - Fetch MCP for general web searches and documentation retrieval
@@ -230,14 +230,16 @@ Lokka MCP is ideal for common Microsoft Graph queries:
 
 #### Interactive MCP Apps (Lokka v2)
 
-EntraPulse Lite supports **all four** of Lokka 2.0's interactive **MCP Apps**, rendered **inline in chat** so you can explore results visually instead of reading raw JSON:
+EntraPulse Lite supports **all six** of Lokka 2.1's interactive **MCP Apps**, rendered **inline in chat** so you can explore results visually instead of reading raw JSON:
 
 - **Graph Explorer** - auto-opens on any Graph query. Shows the exact request (method, API version, path, query parameters) and the results as sortable tables or JSON, and lets you tweak and re-run the query. Compact by default; expands when you open the query.
 - **Multi-Tenant Connection Manager** - sign into one or more tenants (as a user or service principal) and switch the active connection. Open it by asking, e.g. *"open the connection manager"*, *"add a tenant"*, *"switch to a different tenant"*.
 - **Permissions Manager** - review the Graph scopes on your current token and search the full permission catalog. Open it with, e.g. *"open the permissions manager"*, *"review my permissions"*, *"what scopes do I have"*.
 - **Visual Help** - a guided tour of what Lokka can do. Open it with, e.g. *"what can Lokka do?"* or *"show me the Lokka help"*.
+- **Lokka Settings** - one place to manage your Lokka connections and guardrails. Open it with, e.g. *"lokka settings"* or *"manage Lokka"*.
+- **Guardrails** - user-set policy limiting what model-initiated Lokka calls may do (allowed HTTP methods, API allow/deny lists, per-resource id allowlists). Off by default; open it with, e.g. *"guardrails"* or *"limit what the AI can do"*.
 
-The Connections, Permissions, and Help apps open automatically when your request matches one of those intents; otherwise queries run normally and the Graph Explorer is shown.
+The Connections, Permissions, Help, Settings, and Guardrails apps open automatically when your request matches one of those intents; otherwise queries run normally and the Graph Explorer is shown.
 
 How it works and how it stays secure:
 - Apps run in a **sandboxed iframe** (`allow-scripts`, no same-origin) with a per-app **Content-Security-Policy** derived from the app's manifest. Only the official SDK transport serves these `ui://` resources.

--- a/TESTING-MICROSOFT-MCP.md
+++ b/TESTING-MICROSOFT-MCP.md
@@ -105,7 +105,10 @@ To test actual queries against Microsoft's MCP endpoint, you need:
    ```powershell
    Install-Module Microsoft.Entra.Beta -Force -AllowClobber
    Connect-Entra -Scopes 'Application.ReadWrite.All','Directory.Read.All','DelegatedPermissionGrant.ReadWrite.All'
-   Grant-EntraBetaMCPServerPermission -ApplicationName 'EntraPulseLite'
+   # The cmdlet only accepts pre-registered MCP client app names: ChatGPT, Claude,
+   # VisualStudioCode, or VisualStudio. Granting any of these enables the MCP
+   # permissions at the tenant level, which EntraPulse Lite then leverages.
+   Grant-EntraBetaMCPServerPermission -ApplicationName 'ChatGPT'
    ```
 
 2. **Valid Credentials** - Configure your Entra app:

--- a/docs/EntraPulse-Lokka-MCP-Apps-Plan.md
+++ b/docs/EntraPulse-Lokka-MCP-Apps-Plan.md
@@ -15,7 +15,7 @@
 | Bridge design | **Generic MCP Apps host** (works for any MCP Apps server, not only Lokka) |
 | Lokka transport | **Move EntraPulse's Lokka transport onto the official `@modelcontextprotocol/sdk` Client** |
 
-> Note on the transport decision: Lokka 2.0.0 *already* runs on `@modelcontextprotocol/sdk ^1.29.0` on the server side. EntraPulse also already depends on the SDK (`^1.12.1`, resolved `1.29.0`) but talks to Lokka through a **hand-rolled stdio JSON-RPC client**. This plan replaces that custom client with the SDK's `Client` + `StdioClientTransport`, which is what the MCP Apps early-access SDK (`modelcontextprotocol/ext-apps`) is built against.
+> Note on the transport decision: Lokka 2.1.2 *already* runs on `@modelcontextprotocol/sdk ^1.29.0` on the server side. EntraPulse also already depends on the SDK (`^1.12.1`, resolved `1.29.0`) but talks to Lokka through a **hand-rolled stdio JSON-RPC client**. This plan replaces that custom client with the SDK's `Client` + `StdioClientTransport`, which is what the MCP Apps early-access SDK (`modelcontextprotocol/ext-apps`) is built against.
 
 ---
 
@@ -25,21 +25,24 @@
 - Electron + React (MUI) + TypeScript + webpack. MCP clients live in the **main process**; the renderer talks to them over IPC (`mcp:call`, `mcp:listTools`, `mcp:restartLokkaMCPServer`, …).
 - The Lokka path uses custom clients: `StdioMCPClient`, `EnhancedStdioMCPClient`, `ManagedLokkaMCPClient`, `PersistentLokkaMCPClient`, orchestrated by `ExternalLokkaMCPStdioServer`.
 - `StdioMCPClient.initialize()` hardcodes `protocolVersion: '2024-11-05'` and `capabilities: { tools: {} }`. **No UI/apps capability is negotiated.**
-- `src/mcp/constants.ts` pins `@merill/lokka@2.0.0` and filters exposed tools to **three**: `Lokka-Microsoft`, `set-access-token`, `get-auth-status`. The `open-*` UI tools are filtered out.
+- `src/mcp/constants.ts` pins `@merill/lokka@2.1.2` and filters exposed tools to **three**: `Lokka-Microsoft`, `set-access-token`, `get-auth-status`. The `open-*` UI tools are filtered out.
 - Auth is owned by EntraPulse: it injects a token via `set-access-token` and runs Lokka with `USE_CLIENT_TOKEN`. Supporting services already exist: `MCPAuthService`, `MCPAdminConsentHelper`, `MCPScopes`.
 - `ChatComponent.tsx` renders tool output as **stringified JSON / metadata** (`message.metadata.mcpResults`, `traceData`, etc.). There is **no iframe, no `dangerouslySetInnerHTML`, no postMessage bridge** anywhere.
 - `EnhancedLLMService` extracts text/structured content from tool results; it currently does **not** carry `_meta` through to the renderer.
 
-### Lokka 2.0.0 (verified by unpacking the published package)
-- Ships **four UI resources**, registered via `registerResource`:
-  - `ui://lokka/graph-explorer`
-  - `ui://lokka/connections`
-  - `ui://lokka/permissions`
-  - `ui://lokka/help`
-- Tools reference their UI via `_meta["ui/resourceUri"]`.
+### Lokka 2.1.2 (verified by unpacking the published package)
+- Ships **six UI resources**, registered via `registerResource` (this plan's initial draft
+  listed only the first four; Settings + Guardrails were added and are now exposed too):
+  - `ui://lokka/graph-explorer.html`
+  - `ui://lokka/connections.html`
+  - `ui://lokka/permissions.html`
+  - `ui://lokka/help.html`
+  - `ui://lokka/settings.html` (umbrella over Connections + Guardrails)
+  - `ui://lokka/guardrails.html` (user policy on model-originated calls; off by default)
+- Tools reference their UI via `_meta.ui.resourceUri` (and the deprecated flat `_meta["ui/resourceUri"]`).
 - UI resource mimeType is **`text/html;profile=mcp-app`** (note: the announcement blog showed `text/html+mcp` — the spec has since drifted, which is exactly why the contract must be pinned from code, not docs).
 - The `open-graph-explorer`, `open-lokka-connections`, `open-lokka-permissions`, `open-lokka-help` tools are present in the bundle.
-- No version bump is required — everything needed is already in the pinned `2.0.0`.
+- No version bump is required — everything needed is already in the pinned `2.1.2`.
 
 ---
 
@@ -69,7 +72,7 @@
 │      • lifecycle: start / restart / persistence                                 │
 └─────────────────────────────────────────────────────────────────────────────────┘
                                 │ stdio
-                       @merill/lokka 2.0.0 (SDK server, ui:// resources)
+                       @merill/lokka 2.1.2 (SDK server, ui:// resources)
 ```
 
 Two render triggers, one path:

--- a/docs/MCP_APPS_CONTRACT.md
+++ b/docs/MCP_APPS_CONTRACT.md
@@ -4,7 +4,7 @@
 **Method:** extracted from installed source, not docs (the spec is a moving proposal — SEP‑1865 / `ext-apps` early access). Re-verify these strings whenever `@merill/lokka` or `@modelcontextprotocol/sdk` is bumped.
 
 > All values below were read from:
-> - `node_modules/@merill/lokka/build/main.js` and `node_modules/@merill/lokka/build/ui/*.html` (Lokka 2.0.0)
+> - `node_modules/@merill/lokka/build/main.js` and `node_modules/@merill/lokka/build/ui/*.html` (Lokka 2.1.2)
 > - `node_modules/@modelcontextprotocol/sdk/dist/cjs/types.js` and `.../client/index.js` (SDK 1.29.0)
 
 ---
@@ -13,7 +13,7 @@
 
 | Component | Version |
 | --- | --- |
-| `@merill/lokka` | **2.0.0** (pinned in `package.json` + `src/mcp/constants.ts`) |
+| `@merill/lokka` | **2.1.2** (pinned in `package.json` + `src/mcp/constants.ts`) |
 | `@modelcontextprotocol/sdk` | declared `^1.12.1`, **resolved 1.29.0** |
 | SDK `LATEST_PROTOCOL_VERSION` | `2025-11-25` |
 | SDK `DEFAULT_NEGOTIATED_PROTOCOL_VERSION` | `2025-03-26` |
@@ -91,7 +91,7 @@ Lokka's bridge (`window.parent.postMessage(..., "*")`, `addEventListener("messag
 
 ## 4. UI resources (Layer A — `resources/read`)
 
-Four resources, registered unconditionally by Lokka:
+Six resources, registered unconditionally by Lokka 2.1.2:
 
 | Resource URI | Tool that opens it |
 | --- | --- |
@@ -99,10 +99,20 @@ Four resources, registered unconditionally by Lokka:
 | `ui://lokka/connections.html` | `open-lokka-connections` |
 | `ui://lokka/permissions.html` | `open-lokka-permissions` |
 | `ui://lokka/help.html` | `open-lokka-help` |
+| `ui://lokka/settings.html` | `open-lokka-settings` (umbrella over Connections + Guardrails) |
+| `ui://lokka/guardrails.html` | `open-lokka-guardrails` (user policy on model-originated calls) |
 
 > Note: the URIs end in **`.html`** (the plan's draft listed them without the extension — use these).
 
-- **mimeType:** `text/html;profile=mcp-app` (constant `UI_APP_MIME_TYPE`). The announcement blog's `text/html+mcp` is **wrong** for 2.0.0.
+> **Guardrails tool family (bridge-called, not model-exposed).** The Settings and Guardrails
+> apps configure guardrails by relaying `tools/call` over the Layer B bridge to
+> `lokka-get-guardrails-config`, `lokka-set-guardrails-enabled`, `lokka-set-guardrails-scope`,
+> `lokka-remove-guardrails-tenant`, and a directory-search resource picker. These are **allowed**
+> by `LokkaPolicy` (guardrails are user-set policy that limits only Lokka calls, not EntraPulse's
+> auth) and are not added to `LOKKA_AUTH_MUTATING_TOOLS`. Guardrails enforcement is **off by
+> default** in Lokka, so exposing these apps does not change EntraPulse's own query behaviour.
+
+- **mimeType:** `text/html;profile=mcp-app` (constant `UI_APP_MIME_TYPE`). The announcement blog's `text/html+mcp` is **wrong** for 2.1.2.
 - `resources/read` returns `{ contents:[{ uri, mimeType, text:<full HTML>, _meta }] }`. The HTML is self-contained (inline bundled JS) → mount via `<iframe srcdoc>`.
 
 ### Resource `_meta.ui` (drives sandbox/CSP)

--- a/electron-builder-unsigned.json
+++ b/electron-builder-unsigned.json
@@ -14,6 +14,7 @@
       "to": "assets"
     }
   ],
+  "artifactName": "${name}-${version}-${arch}.${ext}",
   "win": {
     "target": [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "entrapulselite",
-  "version": "1.3.1",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "entrapulselite",
-      "version": "1.3.1",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^3.6.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@merill/lokka": "2.0.0",
+        "@merill/lokka": "2.1.2",
         "@microsoft/mgt-components": "^4.6.0",
         "@microsoft/mgt-element": "^4.6.0",
         "@microsoft/mgt-react": "^4.6.0",
@@ -230,6 +230,45 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@azure/identity-cache-persistence": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/identity-cache-persistence/-/identity-cache-persistence-1.3.0.tgz",
+      "integrity": "sha512-gk1utd1YazL+88bwOiDbZdqSu5Y7HxbsmQSXoW1qhGqqvbO5lma81mv4UQkS1vK6l2y/yd1v4IoJoOEtnUjikw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/identity": "^4.7.0",
+        "@azure/msal-node": "^5.1.0",
+        "@azure/msal-node-extensions": "^5.1.0",
+        "keytar": "^7.6.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity-cache-persistence/node_modules/@azure/msal-common": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.10.0.tgz",
+      "integrity": "sha512-iYtjpanlv6963Jprs0MvzIap07V+QhultjQctfbEDQCflsDAEeO3R7XnVA5gk30fhoBFLdgJT7VqO0TGsEsN9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/identity-cache-persistence/node_modules/@azure/msal-node": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.0.tgz",
+      "integrity": "sha512-fXtJX811pX8y8QlrQqBSH6+plvWyKZDI0IxkheAcyAw9OtcpXyFivmTC7eGUqutLWaDlKXuQ3yOESD4zAmkjHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.10.0",
+        "jsonwebtoken": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@azure/logger": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.2.0.tgz",
@@ -286,6 +325,37 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@azure/msal-node-extensions": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node-extensions/-/msal-node-extensions-5.3.0.tgz",
+      "integrity": "sha512-815pyZ+ZEHZnuQCjXLtjGrE/bPmG6FZ8bI/Qx7h5xKC+po8iCQogEcb3eibJiXgv6fdjYjBJuJUEVLEPCwBVTw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.10.0",
+        "@azure/msal-node-runtime": "^0.20.0",
+        "keytar": "^7.8.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node-extensions/node_modules/@azure/msal-common": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.10.0.tgz",
+      "integrity": "sha512-iYtjpanlv6963Jprs0MvzIap07V+QhultjQctfbEDQCflsDAEeO3R7XnVA5gk30fhoBFLdgJT7VqO0TGsEsN9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node-runtime": {
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node-runtime/-/msal-node-runtime-0.20.5.tgz",
+      "integrity": "sha512-DqY28Lpx67AsMbT3FYal3MnDZx62Pblnhp1qA+HGtgEsm3jK8COkJVCrhVsprn80PKQfAOdKRuxgVYyvmv2rOg==",
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1685,7 +1755,7 @@
     },
     "node_modules/@electron/node-gyp": {
       "version": "10.2.0-electron.1",
-      "resolved": "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
+      "resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
       "integrity": "sha512-4MSBTT8y07YUDqf69/vSh80Hh791epYqGtWHO3zSKhYFwQg+gx9wi1PqbqP6YqC4WMsNxZ5l9oDmnWdK5pfCKQ==",
       "dev": true,
       "license": "MIT",
@@ -4253,17 +4323,20 @@
       "license": "MIT"
     },
     "node_modules/@merill/lokka": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@merill/lokka/-/lokka-2.0.0.tgz",
-      "integrity": "sha512-aNYSa96ww8Qx9oI7JEgzS18lyDQj66OPvwXzrnfqZ7jrK2VZ7haFSiiww7G2sPJK0L1+WijBnVSu48Vxl/v/Tg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@merill/lokka/-/lokka-2.1.2.tgz",
+      "integrity": "sha512-sj5gT0+I5Iumr+9wS/jyZ+D51EsfzyaB5GHdPUZ82wxQnUZYOIVD7heC8XX6YeiCz5SCkLPWTd13bOamTr7cMw==",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.3.0",
+        "@azure/identity-cache-persistence": "^1.3.0",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/jsonwebtoken": "^9.0.10",
         "isomorphic-fetch": "^3.0.0",
         "jsonwebtoken": "^9.0.2",
+        "keytar": "^7.9.0",
+        "selfsigned": "^5.5.0",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -4727,6 +4800,18 @@
         }
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4873,6 +4958,163 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -6276,6 +6518,20 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assert": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
@@ -6553,7 +6809,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6574,7 +6829,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -6586,7 +6840,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6943,6 +7196,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/cacache": {
@@ -8213,7 +8475,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -8229,7 +8490,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8251,6 +8511,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deepmerge": {
@@ -8393,7 +8662,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -9701,7 +9969,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -10084,6 +10351,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/expect": {
@@ -10699,6 +10975,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -10919,6 +11201,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -11604,7 +11892,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13812,6 +14099,23 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/keytar/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -15317,7 +15621,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -15433,6 +15736,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -15476,6 +15785,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -15522,7 +15837,6 @@
       "version": "3.87.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
       "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -16737,6 +17051,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -16899,6 +17230,33 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/prettier": {
@@ -17104,7 +17462,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
       "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -17137,6 +17494,24 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.1",
@@ -17244,6 +17619,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -17464,7 +17869,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -17501,6 +17905,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/relateurl": {
       "version": "0.2.7",
@@ -18102,6 +18512,19 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/selfsigned": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -18435,6 +18858,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -18746,7 +19214,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -19122,6 +19589,40 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/minipass": {
@@ -19589,6 +20090,36 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -19925,7 +20456,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utila": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entrapulselite",
   "productName": "EntraPulse Lite",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A freemium desktop application for natural language querying of Microsoft Graph APIs through local LLM integration",
   "main": "dist/main.js",
   "homepage": "https://github.com/darrenjrobinson/EntraPulseLite",
@@ -178,7 +178,7 @@
     "@azure/msal-node": "^3.6.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@merill/lokka": "2.0.0",
+    "@merill/lokka": "2.1.2",
     "@microsoft/mgt-components": "^4.6.0",
     "@microsoft/mgt-element": "^4.6.0",
     "@microsoft/mgt-react": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entrapulselite",
   "productName": "EntraPulse Lite",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A freemium desktop application for natural language querying of Microsoft Graph APIs through local LLM integration",
   "main": "dist/main.js",
   "homepage": "https://github.com/darrenjrobinson/EntraPulseLite",
@@ -90,6 +90,7 @@
         "to": "assets"
       }
     ],
+    "artifactName": "${name}-${version}-${arch}.${ext}",
     "win": {
       "target": [
         {
@@ -107,7 +108,7 @@
       ],
       "icon": "assets/icon.ico",
       "requestedExecutionLevel": "asInvoker",
-      "artifactName": "${productName} ${version}.${ext}"
+      "artifactName": "${name}-${version}-${arch}-portable.${ext}"
     },
     "nsis": {
       "oneClick": false,
@@ -115,7 +116,7 @@
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,
       "shortcutName": "EntraPulse Lite",
-      "artifactName": "${productName} Setup ${version}.${ext}"
+      "artifactName": "${name}-Setup-${version}-${arch}.${ext}"
     },
     "mac": {
       "target": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "entrapulselite",
   "productName": "EntraPulse Lite",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A freemium desktop application for natural language querying of Microsoft Graph APIs through local LLM integration",
   "main": "dist/main.js",
   "homepage": "https://github.com/darrenjrobinson/EntraPulseLite",

--- a/src/auth/AuthService.ts
+++ b/src/auth/AuthService.ts
@@ -1515,9 +1515,12 @@ export class AuthService {
   async getMCPToken(features?: (keyof typeof MCP_PERMISSION_TIERS)[]): Promise<AuthToken | null> {
     if (!this.hasMCPScopes(features)) {
       console.log('⚠️  [AuthService] Missing MCP scopes, requesting them...');
-      return this.requestMCPScopes(features);
+      await this.requestMCPScopes(features);
     }
 
-    return this.getToken();
+    // The Microsoft Enterprise MCP Server requires a token whose audience is the MCP server
+    // (api://e8c77dc2-…/.default), NOT Microsoft Graph. getMCPServerToken() acquires that
+    // audience; getToken() would return a Graph token and fail at the MCP server.
+    return this.getMCPServerToken();
   }
 }

--- a/src/auth/AuthService.ts
+++ b/src/auth/AuthService.ts
@@ -1515,7 +1515,10 @@ export class AuthService {
   async getMCPToken(features?: (keyof typeof MCP_PERMISSION_TIERS)[]): Promise<AuthToken | null> {
     if (!this.hasMCPScopes(features)) {
       console.log('⚠️  [AuthService] Missing MCP scopes, requesting them...');
-      await this.requestMCPScopes(features);
+      const consented = await this.requestMCPScopes(features);
+      if (!consented) {
+        return null;
+      }
     }
 
     // The Microsoft Enterprise MCP Server requires a token whose audience is the MCP server

--- a/src/llm/EnhancedLLMService.ts
+++ b/src/llm/EnhancedLLMService.ts
@@ -1019,6 +1019,11 @@ The current authentication session does not have sufficient permissions to acces
         if (typeof enterpriseData === 'string' && enterpriseData.includes('error occurred')) {
           console.warn('Microsoft Enterprise MCP returned an error:', enterpriseData);
           contextData += `Microsoft Enterprise MCP Error: ${enterpriseData}\n\n`;
+        } else if (enterpriseData && typeof enterpriseData === 'object' && 'error' in enterpriseData) {
+          // An error object (e.g. { error: true, message: '...' }) would otherwise be passed to
+          // processGraphApiData and produce confusing prompt context. Surface the message directly.
+          console.warn('Microsoft Enterprise MCP returned an error object:', enterpriseData);
+          contextData += `Microsoft Enterprise MCP Error: ${(enterpriseData as any).message || JSON.stringify(enterpriseData)}\n\n`;
         } else {
           const processedData = this.processGraphApiData(enterpriseData);
           if (processedData) {

--- a/src/mcp/clients/SdkMcpConnection.ts
+++ b/src/mcp/clients/SdkMcpConnection.ts
@@ -70,7 +70,7 @@ export interface SdkCallToolResult {
 export interface SdkMcpConnectionOptions {
   /** Executable to spawn (e.g. "npx"). */
   command: string;
-  /** Arguments (e.g. ["-y", "@merill/lokka@2.0.0"]). */
+  /** Arguments (e.g. ["-y", "@merill/lokka@2.1.2"]). */
   args: string[];
   /**
    * Environment for the spawned process. This is where the caller injects auth

--- a/src/mcp/constants.ts
+++ b/src/mcp/constants.ts
@@ -1,3 +1,13 @@
+// Lokka's published multi-tenant public client id (mirrors LokkaClientId in @merill/lokka's
+// build/constants.js for the pinned LOKKA_VERSION below). In client-provided-token mode Lokka's
+// AuthManager uses the injected ACCESS_TOKEN and ignores CLIENT_ID — but Lokka's Connection Manager
+// reuses process.env.CLIENT_ID for interactive "add connection" sign-ins. A per-profile app (or
+// EntraPulse Lite's own app) is single-tenant and fails for any OTHER tenant (AADSTS700016:
+// application not found in directory). Lokka's own client is multi-tenant and consentable in any
+// tenant (the same client Lokka uses standalone), so EntraPulse runs Lokka with it in token mode so
+// added connections can sign in anywhere. Re-verify this id when bumping LOKKA_VERSION.
+export const LOKKA_INTERACTIVE_CLIENT_ID = 'a9bac4c3-af0d-4292-9453-9da89e390140';
+
 // Lokka MCP server package constants
 // Pin the version so a new upstream major release (e.g. the silent 0.3.0 -> 2.0.0 jump
 // on npm) cannot reach users untested. Bump deliberately alongside the package.json
@@ -31,16 +41,21 @@ export const LOKKA_EXPOSED_TOOLS = [
   ...LOKKA_UI_APP_TOOLS
 ];
 
-// Lokka tools that PERFORM authentication/connection mutations. EntraPulse owns auth,
-// so these are denied when initiated from an MCP App iframe (policy Level A). Read/display
-// tools (lokka-list-connections, lokka-get-permissions, get-auth-status, Lokka-Microsoft)
-// are NOT listed and remain allowed. See docs/EntraPulse-Lokka-MCP-Apps-Plan.md §4.
+// Lokka tools blocked when initiated from an MCP App iframe. EntraPulse owns the PRIMARY
+// connection (injected as Lokka's "env" connection via client-token mode) and owns permission
+// consent, so these stay denied with a redirect to EntraPulse's settings:
+//   - set-access-token        — EntraPulse's primary-token injection channel; the app must not
+//                               override it.
+//   - lokka-consent-permissions / add-graph-permission — permission grants belong to EntraPulse's
+//                               own auth/consent flow.
+//
+// Lokka's CONNECTION-management tools (lokka-add-user-connection, lokka-add-sp-connection,
+// switch-lokka-connection, lokka-set-active-connection, lokka-remove-connection,
+// lokka-list-connections) are deliberately NOT listed: Lokka owns additional connections, doing
+// its own sign-in and routing Graph calls through the active connection's own credential
+// (connectionManager.getActiveClient), so the Connection Manager works natively while the
+// EntraPulse-owned primary connection remains available. See docs/EntraPulse-Lokka-MCP-Apps-Plan.md §4.
 export const LOKKA_AUTH_MUTATING_TOOLS = [
-  'lokka-add-user-connection',
-  'lokka-add-sp-connection',
-  'lokka-remove-connection',
-  'lokka-set-active-connection',
-  'switch-lokka-connection',
   'lokka-consent-permissions',
   'add-graph-permission',
   'set-access-token'

--- a/src/mcp/constants.ts
+++ b/src/mcp/constants.ts
@@ -13,25 +13,29 @@ export const LOKKA_INTERACTIVE_CLIENT_ID = 'a9bac4c3-af0d-4292-9453-9da89e390140
 // on npm) cannot reach users untested. Bump deliberately alongside the package.json
 // dependency and re-run the Lokka integration tests.
 export const LOKKA_PACKAGE_NAME = '@merill/lokka';
-export const LOKKA_VERSION = '2.0.0';
+export const LOKKA_VERSION = '2.1.2';
 export const LOKKA_PINNED_PACKAGE = `${LOKKA_PACKAGE_NAME}@${LOKKA_VERSION}`;
 export const LOKKA_NPX_ARGS = ['-y', LOKKA_PINNED_PACKAGE];
 
-// Lokka v2.0.0 registers 16 tools, including connection management
-// (lokka-add-sp-connection accepts client secrets), interactive consent, and
-// browser-launching helpers. EntraPulse Lite manages authentication and
-// permissions itself, so only these tools are exposed to the LLM.
+// Lokka v2.1.2 registers many tools, including connection management
+// (lokka-add-sp-connection accepts client secrets), interactive consent, guardrails
+// configuration, and browser-launching helpers. EntraPulse Lite manages authentication
+// and permissions itself, so only these tools are exposed to the LLM.
 //
-// The `open-*` tools open Lokka's interactive MCP Apps (graph explorer, connections,
-// permissions, help). They carry a `_meta.ui.resourceUri` and are rendered inline by
-// McpAppFrame. They are gated at runtime by the MCP Apps host's policy (auth-mutating
-// calls from those apps are intercepted), so exposing them does not let the apps bypass
-// EntraPulse's auth ownership. See docs/EntraPulse-Lokka-MCP-Apps-Plan.md.
+// The `open-*` tools open Lokka's six interactive MCP Apps (graph explorer, connections,
+// permissions, help, settings, guardrails). They carry a `_meta.ui.resourceUri` and are
+// rendered inline by McpAppFrame. They are gated at runtime by the MCP Apps host's policy
+// (auth-mutating calls from those apps are intercepted), so exposing them does not let the
+// apps bypass EntraPulse's auth ownership. Settings is an umbrella over Connections +
+// Guardrails; Guardrails is user-set policy limiting model-originated Lokka calls.
+// See docs/EntraPulse-Lokka-MCP-Apps-Plan.md.
 export const LOKKA_UI_APP_TOOLS = [
   'open-graph-explorer',
   'open-lokka-connections',
   'open-lokka-permissions',
-  'open-lokka-help'
+  'open-lokka-help',
+  'open-lokka-settings',
+  'open-lokka-guardrails'
 ];
 
 export const LOKKA_EXPOSED_TOOLS = [
@@ -55,6 +59,11 @@ export const LOKKA_EXPOSED_TOOLS = [
 // its own sign-in and routing Graph calls through the active connection's own credential
 // (connectionManager.getActiveClient), so the Connection Manager works natively while the
 // EntraPulse-owned primary connection remains available. See docs/EntraPulse-Lokka-MCP-Apps-Plan.md §4.
+//
+// Lokka's GUARDRAILS-config tools (lokka-get-guardrails-config, lokka-set-guardrails-enabled,
+// lokka-set-guardrails-scope, lokka-remove-guardrails-tenant, and the guardrails resource picker)
+// are also deliberately NOT listed: guardrails are user-set policy that only limits Lokka calls,
+// not EntraPulse's auth, so the Settings/Guardrails apps configure them natively over the bridge.
 export const LOKKA_AUTH_MUTATING_TOOLS = [
   'lokka-consent-permissions',
   'add-graph-permission',
@@ -120,6 +129,28 @@ export const LOKKA_APP_INTENTS: Array<{ tool: string; resourceUri: string; patte
       /\bhelp\s+tour\b/i,
       /\bshow\s+(me\s+)?(the\s+)?lokka\s+help\b/i,
       /\bgetting\s+started\s+with\s+lokka\b/i,
+    ],
+  },
+  {
+    // Lokka Settings is an umbrella app over Connections + Guardrails. Help app
+    // "Open it now" -> openMessage "lokka settings".
+    tool: 'open-lokka-settings',
+    resourceUri: 'ui://lokka/settings.html',
+    patterns: [
+      /\blokka\s+settings\b/i,
+      /\bmanage\s+lokka\b/i,
+      /\blokka\s+config(uration)?\b/i,
+      /\bopen\s+(the\s+)?lokka\s+settings\b/i,
+    ],
+  },
+  {
+    // Guardrails = user-set policy limiting what model tool calls may do.
+    tool: 'open-lokka-guardrails',
+    resourceUri: 'ui://lokka/guardrails.html',
+    patterns: [
+      /\b(lokka\s+)?guardrails?\b/i,
+      /\b(limit|restrict)\s+(what\s+)?(the\s+)?(ai|model)\s+can\b/i,
+      /\bmanage\s+(my\s+)?guardrails\b/i,
     ],
   },
 ];

--- a/src/mcp/host/ServerPolicy.ts
+++ b/src/mcp/host/ServerPolicy.ts
@@ -69,12 +69,15 @@ export class LokkaPolicy implements ServerPolicy {
 
     if (method === 'tools/call') {
       const toolName = params?.name;
+      // EntraPulse owns the primary connection's token injection and permission consent, so those
+      // tools are denied. Lokka's own connection-management tools (add/switch/remove/list) are
+      // allowed to relay — Lokka owns additional connections.
       if (typeof toolName === 'string' && this.mutatingTools.includes(toolName)) {
         return {
           action: 'deny',
           reason:
-            'EntraPulse Lite manages authentication and connections itself. ' +
-            'Use EntraPulse Lite’s account/settings to sign in, add connections, or grant permissions.',
+            'EntraPulse Lite manages this itself. ' +
+            'Use EntraPulse Lite’s account/settings to grant permissions or change the active tenant.',
           redirect: 'entrapulse://settings/authentication',
         };
       }

--- a/src/mcp/servers/MicrosoftEnterpriseMCPServer.ts
+++ b/src/mcp/servers/MicrosoftEnterpriseMCPServer.ts
@@ -191,7 +191,7 @@ export class MicrosoftEnterpriseMCPServer implements MCPServerHandlers {
   private async suggestQueries(
     params: MicrosoftGraphSuggestQueriesParams
   ): Promise<any> {
-    const { user_query } = params;
+    const { user_query } = params || {};
 
     console.log('[MicrosoftEnterpriseMCPServer] Suggesting queries for:', user_query);
 
@@ -212,7 +212,7 @@ export class MicrosoftEnterpriseMCPServer implements MCPServerHandlers {
   private async executeGraphQuery(
     params: MicrosoftGraphGetParams
   ): Promise<any> {
-    let { url, method = 'GET' } = params;
+    let { url, method = 'GET' } = params || {};
 
     // Normalize URL (remove leading slash if present)
     if (url.startsWith('/')) {
@@ -241,7 +241,7 @@ export class MicrosoftEnterpriseMCPServer implements MCPServerHandlers {
   private async listProperties(
     params: MicrosoftGraphListPropertiesParams
   ): Promise<any> {
-    const { entity_type } = params;
+    const { entity_type } = params || {};
 
     console.log('[MicrosoftEnterpriseMCPServer] Listing properties for:', entity_type);
 

--- a/src/mcp/servers/MicrosoftEnterpriseMCPServer.ts
+++ b/src/mcp/servers/MicrosoftEnterpriseMCPServer.ts
@@ -12,7 +12,7 @@
 
 import { MCPServerConfig } from '../../types';
 import { MCPServerHandlers } from './MCPServerFactory';
-import { MicrosoftEnterpriseMCPClient, MCPResponse } from '../clients/MicrosoftEnterpriseMCPClient';
+import { MicrosoftEnterpriseMCPClient } from '../clients/MicrosoftEnterpriseMCPClient';
 import { AuthService } from '../../auth/AuthService';
 import { MCP_PERMISSION_TIERS } from '../../auth/MCPScopes';
 
@@ -190,26 +190,19 @@ export class MicrosoftEnterpriseMCPServer implements MCPServerHandlers {
    */
   private async suggestQueries(
     params: MicrosoftGraphSuggestQueriesParams
-  ): Promise<MicrosoftGraphSuggestQueriesResponse> {
-    const { user_query, top = 5 } = params;
+  ): Promise<any> {
+    const { user_query } = params;
 
     console.log('[MicrosoftEnterpriseMCPServer] Suggesting queries for:', user_query);
 
-    // Cache key includes the query and top parameter
-    const cacheOptions = { skipCache: false };
+    // The Microsoft Enterprise MCP server exposes this as an MCP tool. Invoke it via the
+    // client's callTool helper (it has no HTTP-style post()). The preview tool takes a
+    // generic, anonymized intent description only.
+    const result = await this.client.suggestQueries(user_query);
 
-    const response = await this.client.post<MicrosoftGraphSuggestQueriesResponse>(
-      '/tools/microsoft_graph_suggest_queries',
-      { user_query, top },
-      cacheOptions
-    );
+    console.log('[MicrosoftEnterpriseMCPServer] Suggestions received');
 
-    console.log('[MicrosoftEnterpriseMCPServer] Suggestions received:', {
-      count: response.data.suggestions?.length || 0,
-      cached: response.cached
-    });
-
-    return response.data;
+    return result;
   }
 
   /**
@@ -218,7 +211,7 @@ export class MicrosoftEnterpriseMCPServer implements MCPServerHandlers {
    */
   private async executeGraphQuery(
     params: MicrosoftGraphGetParams
-  ): Promise<MicrosoftGraphGetResponse> {
+  ): Promise<any> {
     let { url, method = 'GET' } = params;
 
     // Normalize URL (remove leading slash if present)
@@ -232,20 +225,13 @@ export class MicrosoftEnterpriseMCPServer implements MCPServerHandlers {
 
     console.log('[MicrosoftEnterpriseMCPServer] Executing Graph query:', url);
 
-    // Don't cache actual Graph queries (data freshness is important)
-    const response = await this.client.post<MicrosoftGraphGetResponse>(
-      '/tools/microsoft_graph_get',
-      { url, method },
-      { skipCache: true }
-    );
+    // Invoke the upstream microsoft_graph_get tool via the MCP client. The MCP server
+    // enforces user privileges and granted scopes; only GET is supported in preview.
+    const result = await this.client.graphGet(url);
 
-    console.log('[MicrosoftEnterpriseMCPServer] Query executed successfully:', {
-      hasData: !!response.data.data,
-      hasNextLink: !!response.data.nextLink,
-      count: response.data.count
-    });
+    console.log('[MicrosoftEnterpriseMCPServer] Query executed successfully');
 
-    return response.data;
+    return result;
   }
 
   /**
@@ -254,25 +240,17 @@ export class MicrosoftEnterpriseMCPServer implements MCPServerHandlers {
    */
   private async listProperties(
     params: MicrosoftGraphListPropertiesParams
-  ): Promise<MicrosoftGraphListPropertiesResponse> {
+  ): Promise<any> {
     const { entity_type } = params;
 
     console.log('[MicrosoftEnterpriseMCPServer] Listing properties for:', entity_type);
 
-    // Cache entity schemas for 24 hours (they rarely change)
-    const response = await this.client.post<MicrosoftGraphListPropertiesResponse>(
-      '/tools/microsoft_graph_list_properties',
-      { entity_type },
-      { skipCache: false }
-    );
+    // Invoke the upstream microsoft_graph_list_properties tool via the MCP client.
+    const result = await this.client.listProperties(entity_type);
 
-    console.log('[MicrosoftEnterpriseMCPServer] Properties listed:', {
-      entity_type: response.data.entity_type,
-      propertyCount: response.data.properties?.length || 0,
-      cached: response.cached
-    });
+    console.log('[MicrosoftEnterpriseMCPServer] Properties listed');
 
-    return response.data;
+    return result;
   }
 
   /**

--- a/src/mcp/servers/lokka/ExternalLokkaMCPStdioServer.ts
+++ b/src/mcp/servers/lokka/ExternalLokkaMCPStdioServer.ts
@@ -10,7 +10,7 @@ import { ManagedLokkaMCPClient } from '../../clients/ManagedLokkaMCPClient';
 import { PersistentLokkaMCPClient } from '../../clients/PersistentLokkaMCPClient';
 import { SdkMcpConnection } from '../../clients/SdkMcpConnection';
 import { ConfigService } from '../../../shared/ConfigService';
-import { LOKKA_NPX_ARGS, LOKKA_EXPOSED_TOOLS } from '../../constants';
+import { LOKKA_NPX_ARGS, LOKKA_EXPOSED_TOOLS, LOKKA_INTERACTIVE_CLIENT_ID } from '../../constants';
 import { VERSION } from '../../../shared/version';
 
 export interface ExternalLokkaMCPServerConfig extends MCPServerConfig {
@@ -155,9 +155,44 @@ export class ExternalLokkaMCPStdioServer {
     }
   }
 
+  /**
+   * In client-provided-token mode, ensure Lokka uses its OWN multi-tenant client id so its Connection
+   * Manager can sign in to other tenants. The per-profile app (and EntraPulse Lite's own app) is
+   * single-tenant and fails interactive sign-in to other tenants (AADSTS700016); Lokka's published
+   * client (LOKKA_INTERACTIVE_CLIENT_ID) is consentable in any tenant. Only rewrites a profile-specific
+   * config (USE_CLIENT_TOKEN with a non-'common' TENANT_ID); the already-multi-tenant modes (Enhanced
+   * Graph Access / default delegated, which use TENANT_ID='common') are left untouched. Idempotent and
+   * safe to call on every (re)start.
+   */
+  private applyMultiTenantClientIdForAddedConnections(): void {
+    const env = this.config.env;
+    if (!env || env.USE_CLIENT_TOKEN !== 'true' || !env.CLIENT_ID) return;
+
+    const tenantId = (env.TENANT_ID || '').toLowerCase();
+    const isSpecificTenant = tenantId !== '' && tenantId !== 'common' && tenantId !== 'organizations';
+    if (!isSpecificTenant) return;
+
+    if (env.CLIENT_ID === LOKKA_INTERACTIVE_CLIENT_ID) return;
+
+    console.log(
+      `🔧 [Lokka Startup] Client-token mode: substituting Lokka's multi-tenant CLIENT_ID (${LOKKA_INTERACTIVE_CLIENT_ID.substring(0, 8)}…) ` +
+      `for Lokka's add-connection sign-ins (was ${env.CLIENT_ID.substring(0, 8)}…). Primary connection still uses the injected token.`
+    );
+    this.config.env = { ...env, CLIENT_ID: LOKKA_INTERACTIVE_CLIENT_ID };
+  }
+
   private async performStartup(): Promise<void> {
     console.log('🚀 [Lokka Startup] Starting Lokka MCP server...');
-    
+
+    // Client-token mode + a profile-specific CLIENT_ID: EntraPulse injects the primary connection's
+    // ACCESS_TOKEN (Lokka's AuthManager ignores CLIENT_ID here), but Lokka's Connection Manager reuses
+    // process.env.CLIENT_ID for interactive "add connection" sign-ins. A per-profile single-tenant app
+    // can't sign in to OTHER tenants (AADSTS700016), so swap in EntraPulse's multi-tenant client for the
+    // add-connection path. Multi-tenant auth modes already use TENANT_ID='common' and are left untouched;
+    // the primary connection still authenticates with the injected token (CLIENT_ID is otherwise only the
+    // env connection's cosmetic identifier in this mode).
+    this.applyMultiTenantClientIdForAddedConnections();
+
     // Add debugging that will show in DevTools via IPC
     const env = this.config.env || {};
     const debugInfo = {

--- a/src/mcp/servers/lokka/ExternalLokkaMCPStdioServer.ts
+++ b/src/mcp/servers/lokka/ExternalLokkaMCPStdioServer.ts
@@ -169,7 +169,7 @@ export class ExternalLokkaMCPStdioServer {
     if (!env || env.USE_CLIENT_TOKEN !== 'true' || !env.CLIENT_ID) return;
 
     const tenantId = (env.TENANT_ID || '').toLowerCase();
-    const isSpecificTenant = tenantId !== '' && tenantId !== 'common' && tenantId !== 'organizations';
+    const isSpecificTenant = tenantId !== '' && tenantId !== 'common' && tenantId !== 'organizations' && tenantId !== 'consumers';
     if (!isSpecificTenant) return;
 
     if (env.CLIENT_ID === LOKKA_INTERACTIVE_CLIENT_ID) return;

--- a/src/renderer/components/ChatComponent.tsx
+++ b/src/renderer/components/ChatComponent.tsx
@@ -78,7 +78,7 @@ export const ChatComponent: React.FC<ChatComponentProps> = () => {
   const [copyStatus, setCopyStatus] = useState<{ [key: string]: boolean }>({});
   const [sessionId, setSessionId] = useState<string>(() => `session-${Date.now()}`);
   const [activeTenantProfile, setActiveTenantProfile] = useState<{ name: string; entraConfig?: { tenantId?: string } } | null>(null);
-  
+
   // Cloud LLM status tracking
   const [cloudLLMStatus, setCloudLLMStatus] = useState<{
     isAvailable: boolean;

--- a/src/renderer/components/McpAppFrame.tsx
+++ b/src/renderer/components/McpAppFrame.tsx
@@ -217,8 +217,17 @@ export const McpAppFrame: React.FC<McpAppFrameProps> = ({ uiResource, onSendMess
               method: msg.method,
               params: msg.params,
             });
-            if (response?.error) reply({ error: response.error });
-            else reply({ result: response?.result });
+            // An IPC failure leaves `response` undefined; surface it as a JSON-RPC error rather
+            // than an empty success so the app doesn't silently treat it as a valid result.
+            if (!response) {
+              reply({ error: { code: -32603, message: 'No response from host.' } });
+              return;
+            }
+            if (response.error) {
+              reply({ error: response.error });
+              return;
+            }
+            reply({ result: response.result });
             return;
           }
 

--- a/src/renderer/components/McpAppFrame.tsx
+++ b/src/renderer/components/McpAppFrame.tsx
@@ -1,8 +1,8 @@
 // McpAppFrame.tsx
 //
 // Phase 3 of the Lokka MCP Apps migration. Renders an interactive MCP App (Lokka's graph
-// explorer / connections / permissions / help) inline in chat inside a sandboxed iframe,
-// and implements the HOST side of the postMessage ⇄ JSON-RPC bridge.
+// explorer / connections / permissions / help / settings / guardrails) inline in chat inside
+// a sandboxed iframe, and implements the HOST side of the postMessage ⇄ JSON-RPC bridge.
 //
 // Protocol is pinned in docs/MCP_APPS_CONTRACT.md:
 //   - iframe → host (requests):  ui/initialize, tools/call, resources/read, ui/message,
@@ -272,6 +272,8 @@ export const McpAppFrame: React.FC<McpAppFrameProps> = ({ uiResource, onSendMess
       'ui://lokka/connections.html': 'Connections',
       'ui://lokka/permissions.html': 'Permissions',
       'ui://lokka/help.html': 'Help',
+      'ui://lokka/settings.html': 'Lokka Settings',
+      'ui://lokka/guardrails.html': 'Guardrails',
     };
     return map[resourceUri] || 'Interactive App';
   }, [resourceUri]);

--- a/src/renderer/components/common/UpdateNotification.tsx
+++ b/src/renderer/components/common/UpdateNotification.tsx
@@ -50,29 +50,32 @@ export const UpdateNotification: React.FC = () => {
 
     if (electronAPI?.on) {
       // Update checking
-      electronAPI.on('update:checking-for-update', () => {
+      // NOTE: the preload `on` wrapper forwards Electron's raw ipcRenderer
+      // listener signature, so the IpcRendererEvent is always the FIRST arg
+      // and the payload is the SECOND. (See handleMainDebug in App.tsx.)
+      electronAPI.on('update:checking-for-update', (_event: any) => {
         showSnackbar('Checking for updates...', 'info');
       });
 
       // Update available
-      electronAPI.on('update:available', (info: UpdateInfo) => {
+      electronAPI.on('update:available', (_event: any, info: UpdateInfo) => {
         setUpdateAvailable(info);
         showSnackbar(`Update ${info.version} is available!`, 'info');
       });
 
       // Update not available
-      electronAPI.on('update:not-available', () => {
+      electronAPI.on('update:not-available', (_event: any) => {
         showSnackbar('You are using the latest version', 'success');
       });
 
       // Download progress
-      electronAPI.on('update:download-progress', (progress: UpdateProgress) => {
+      electronAPI.on('update:download-progress', (_event: any, progress: UpdateProgress) => {
         setDownloadProgress(progress);
         setIsDownloading(true);
       });
 
       // Update downloaded
-      electronAPI.on('update:downloaded', (info: UpdateInfo) => {
+      electronAPI.on('update:downloaded', (_event: any, info: UpdateInfo) => {
         setUpdateDownloaded(info);
         setIsDownloading(false);
         setDownloadProgress(null);
@@ -80,7 +83,7 @@ export const UpdateNotification: React.FC = () => {
       });
 
       // Update error
-      electronAPI.on('update:error', (error: string | Error | unknown) => {
+      electronAPI.on('update:error', (_event: any, error: string | Error | unknown) => {
         setIsDownloading(false);
         setDownloadProgress(null);
         

--- a/src/renderer/components/common/UpdateNotification.tsx
+++ b/src/renderer/components/common/UpdateNotification.tsx
@@ -100,8 +100,16 @@ export const UpdateNotification: React.FC = () => {
             errorMessage = 'Update check failed - network or server error';
           }
         }
-        
-        showSnackbar(`Update error: ${errorMessage}`, 'error');
+
+        // Some "errors" from electron-updater are expected, benign states rather
+        // than real failures (no published releases yet, already up to date, or
+        // running an unpackaged dev build). Surface those as info, not a red error.
+        const isBenign = /no releases available|normal for development|latest version|up to date|not packed|dev update config/i.test(errorMessage);
+        if (isBenign) {
+          showSnackbar(errorMessage, 'info');
+        } else {
+          showSnackbar(`Update error: ${errorMessage}`, 'error');
+        }
       });
     }
 

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,4 +1,4 @@
 // Central location for version information
 // This should match the version in package.json
 
-export const VERSION = '1.3.1';
+export const VERSION = '1.3.2';

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,4 +1,4 @@
 // Central location for version information
 // This should match the version in package.json
 
-export const VERSION = '1.3.3';
+export const VERSION = '1.3.4';

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,4 +1,4 @@
 // Central location for version information
 // This should match the version in package.json
 
-export const VERSION = '1.3.2';
+export const VERSION = '1.3.3';

--- a/src/tests/integration/external-lokka-mcp-server.test.ts
+++ b/src/tests/integration/external-lokka-mcp-server.test.ts
@@ -38,7 +38,7 @@ describe('ExternalLokkaMCPStdioServer Four-Tier Architecture', () => {
       enabled: true,
       port: 0, // Not used for stdio but required by interface
       command: 'npx',
-      args: ['-y', '@merill/lokka@2.0.0'],
+      args: ['-y', '@merill/lokka@2.1.2'],
       env: {
         TENANT_ID: 'test-tenant-id',
         CLIENT_ID: 'test-client-id',
@@ -295,7 +295,7 @@ describe('Lokka MCP Server Configuration Validation', () => {
       enabled: true,
       port: 0,
       command: 'npx',
-      args: ['-y', '@merill/lokka@2.0.0'],
+      args: ['-y', '@merill/lokka@2.1.2'],
       env: {
         TENANT_ID: 'common',
         CLIENT_ID: '14d82eec-204b-4c2f-b7e8-296a70dab67e', // Microsoft Graph PowerShell
@@ -315,7 +315,7 @@ describe('Lokka MCP Server Configuration Validation', () => {
       enabled: true,
       port: 0,
       command: 'npx',
-      args: ['-y', '@merill/lokka@2.0.0'],
+      args: ['-y', '@merill/lokka@2.1.2'],
       env: {
         TENANT_ID: 'custom-tenant-id',
         CLIENT_ID: 'custom-client-id',

--- a/src/tests/integration/lokka-mcp-integration.test.ts
+++ b/src/tests/integration/lokka-mcp-integration.test.ts
@@ -29,7 +29,7 @@ describe('Lokka MCP Integration Tests', () => {
     enabled: true,
     port: 0, // Added required port field
     command: 'npx',
-    args: ['-y', '@merill/lokka@2.0.0'],
+    args: ['-y', '@merill/lokka@2.1.2'],
     env: {
       TENANT_ID: 'test-tenant-id',
       CLIENT_ID: 'test-client-id',

--- a/src/tests/integration/lokka-mcp-integration.test.ts
+++ b/src/tests/integration/lokka-mcp-integration.test.ts
@@ -8,6 +8,7 @@ import { EnhancedStdioMCPClient } from '../../mcp/clients/EnhancedStdioMCPClient
 import { StdioMCPClient } from '../../mcp/clients/StdioMCPClient';
 import { MCPAuthService } from '../../mcp/auth/MCPAuthService';
 import { ConfigService } from '../../shared/ConfigService';
+import { LOKKA_INTERACTIVE_CLIENT_ID } from '../../mcp/constants';
 
 // Mock dependencies
 jest.mock('../../mcp/auth/MCPAuthService');
@@ -93,7 +94,9 @@ describe('Lokka MCP Integration Tests', () => {
 
       expect(PersistentLokkaMCPClient).toHaveBeenCalledWith({
         TENANT_ID: 'test-tenant-id',
-        CLIENT_ID: 'test-client-id',
+        // Client-token mode + profile-specific tenant: the per-profile CLIENT_ID is replaced with
+        // Lokka's multi-tenant client so its Connection Manager can sign in to other tenants.
+        CLIENT_ID: LOKKA_INTERACTIVE_CLIENT_ID,
         ACCESS_TOKEN: 'test-access-token',
         USE_CLIENT_TOKEN: 'true',
         LOKKA_USE_SDK_TRANSPORT: 'false'

--- a/src/tests/integration/lokka-sdk-transport.test.ts
+++ b/src/tests/integration/lokka-sdk-transport.test.ts
@@ -39,6 +39,7 @@ jest.mock('../../shared/ConfigService');
 import { ExternalLokkaMCPStdioServer, ExternalLokkaMCPServerConfig } from '../../mcp/servers/lokka/ExternalLokkaMCPStdioServer';
 import { MCPAuthService } from '../../mcp/auth/MCPAuthService';
 import { ConfigService } from '../../shared/ConfigService';
+import { LOKKA_INTERACTIVE_CLIENT_ID } from '../../mcp/constants';
 
 describe('ExternalLokkaMCPStdioServer — tier-0 SDK transport', () => {
   let server: ExternalLokkaMCPStdioServer;
@@ -95,7 +96,10 @@ describe('ExternalLokkaMCPStdioServer — tier-0 SDK transport', () => {
       expect.objectContaining({
         command: 'npx',
         args: ['-y', '@merill/lokka@2.0.0'],
-        env: expect.objectContaining({ TENANT_ID: 't', CLIENT_ID: 'c' }),
+        // In client-provided-token mode with a profile-specific tenant, the per-profile CLIENT_ID
+        // ('c') is replaced with Lokka's own multi-tenant client so its Connection Manager can sign
+        // in to other tenants. The primary connection still authenticates with the injected token.
+        env: expect.objectContaining({ TENANT_ID: 't', CLIENT_ID: LOKKA_INTERACTIVE_CLIENT_ID }),
       })
     );
     expect(mockSdkStart).toHaveBeenCalledTimes(1);

--- a/src/tests/integration/lokka-sdk-transport.test.ts
+++ b/src/tests/integration/lokka-sdk-transport.test.ts
@@ -55,8 +55,12 @@ describe('ExternalLokkaMCPStdioServer — tier-0 SDK transport', () => {
       { name: 'Lokka-Microsoft', description: 'graph', inputSchema: { type: 'object' }, _meta: { ui: { resourceUri: 'ui://lokka/graph-explorer.html' } } },
       { name: 'set-access-token', description: 'set token', inputSchema: { type: 'object' } },
       { name: 'get-auth-status', description: 'status', inputSchema: { type: 'object' } },
-      // Should be filtered out by the current allowlist (Phase 1).
+      // The open-* UI app tools are exposed (Phase 2) and rendered inline by McpAppFrame.
       { name: 'open-graph-explorer', description: 'ui', inputSchema: { type: 'object' } },
+      { name: 'open-lokka-settings', description: 'ui', inputSchema: { type: 'object' } },
+      { name: 'open-lokka-guardrails', description: 'ui', inputSchema: { type: 'object' } },
+      // Not on the exposed allowlist — should be filtered out (bridge-called only).
+      { name: 'lokka-set-guardrails-enabled', description: 'internal', inputSchema: { type: 'object' } },
     ]);
     mockSdkCallTool.mockResolvedValue({
       content: [{ type: 'text', text: '{}' }],
@@ -77,7 +81,7 @@ describe('ExternalLokkaMCPStdioServer — tier-0 SDK transport', () => {
       enabled: true,
       port: 0,
       command: 'npx',
-      args: ['-y', '@merill/lokka@2.0.0'],
+      args: ['-y', '@merill/lokka@2.1.2'],
       env: { TENANT_ID: 't', CLIENT_ID: 'c', ACCESS_TOKEN: 'tok', USE_CLIENT_TOKEN: 'true' },
     };
 
@@ -95,7 +99,7 @@ describe('ExternalLokkaMCPStdioServer — tier-0 SDK transport', () => {
     expect(mockSdkCtor).toHaveBeenCalledWith(
       expect.objectContaining({
         command: 'npx',
-        args: ['-y', '@merill/lokka@2.0.0'],
+        args: ['-y', '@merill/lokka@2.1.2'],
         // In client-provided-token mode with a profile-specific tenant, the per-profile CLIENT_ID
         // ('c') is replaced with Lokka's own multi-tenant client so its Connection Manager can sign
         // in to other tenants. The primary connection still authenticates with the injected token.
@@ -123,8 +127,13 @@ describe('ExternalLokkaMCPStdioServer — tier-0 SDK transport', () => {
     expect(names).toContain('Lokka-Microsoft');
     expect(names).toContain('set-access-token');
     expect(names).toContain('get-auth-status');
-    // Phase 2: the open-* UI app tools are now exposed (no longer filtered).
+    // Phase 2: the open-* UI app tools are now exposed (no longer filtered), including
+    // Lokka 2.1.2's Settings and Guardrails apps.
     expect(names).toContain('open-graph-explorer');
+    expect(names).toContain('open-lokka-settings');
+    expect(names).toContain('open-lokka-guardrails');
+    // Bridge-only tools (e.g. guardrails config) stay off the model-exposed allowlist.
+    expect(names).not.toContain('lokka-set-guardrails-enabled');
   });
 
   it('routes callTool through the SDK transport and preserves _meta', async () => {

--- a/src/tests/unit/McpAppsHost.test.ts
+++ b/src/tests/unit/McpAppsHost.test.ts
@@ -17,7 +17,16 @@ describe('ServerPolicy', () => {
       expect(policy.evaluate('resources/read', { uri: 'ui://lokka/graph-explorer.html' }).action).toBe('allow');
     });
 
-    it('denies every auth-mutating tool with a redirect hint', () => {
+    it('allows Lokka-owned connection-management tools to relay (add/switch/set-active/remove)', () => {
+      for (const name of ['lokka-add-user-connection', 'lokka-add-sp-connection', 'switch-lokka-connection', 'lokka-set-active-connection', 'lokka-remove-connection']) {
+        expect(policy.evaluate('tools/call', { name }).action).toBe('allow');
+      }
+    });
+
+    it('denies the EntraPulse-owned auth tools with a redirect hint', () => {
+      expect(LOKKA_AUTH_MUTATING_TOOLS).toEqual(
+        expect.arrayContaining(['lokka-consent-permissions', 'add-graph-permission', 'set-access-token'])
+      );
       for (const name of LOKKA_AUTH_MUTATING_TOOLS) {
         const d = policy.evaluate('tools/call', { name });
         expect(d.action).toBe('deny');
@@ -69,11 +78,17 @@ describe('McpAppsHost', () => {
     expect(res.error).toBeUndefined();
   });
 
-  it('blocks an auth-mutating tool with a policy-denied error and does NOT call the connection', async () => {
-    const res = await host.handleRpc('external-lokka', { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'lokka-add-sp-connection', arguments: {} } });
+  it('blocks a still-denied auth-mutating tool with a policy-denied error and does NOT call the connection', async () => {
+    const res = await host.handleRpc('external-lokka', { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'lokka-consent-permissions', arguments: {} } });
     expect(conn.callTool).not.toHaveBeenCalled();
     expect(res.error?.code).toBe(-32001);
     expect(res.error?.data?.redirect).toContain('settings');
+  });
+
+  it('relays a Lokka connection-management tool (add-user-connection) to the connection', async () => {
+    const res = await host.handleRpc('external-lokka', { jsonrpc: '2.0', id: 7, method: 'tools/call', params: { name: 'lokka-add-user-connection', arguments: { tenantId: 'contoso.com' } } });
+    expect(conn.callTool).toHaveBeenCalledWith('lokka-add-user-connection', { tenantId: 'contoso.com' });
+    expect(res.error).toBeUndefined();
   });
 
   it('forwards resources/read', async () => {

--- a/src/tests/unit/McpAppsHost.test.ts
+++ b/src/tests/unit/McpAppsHost.test.ts
@@ -23,6 +23,12 @@ describe('ServerPolicy', () => {
       }
     });
 
+    it('allows the guardrails-config tools the Settings/Guardrails apps drive over the bridge', () => {
+      for (const name of ['lokka-get-guardrails-config', 'lokka-set-guardrails-enabled', 'lokka-set-guardrails-scope', 'lokka-remove-guardrails-tenant']) {
+        expect(policy.evaluate('tools/call', { name }).action).toBe('allow');
+      }
+    });
+
     it('denies the EntraPulse-owned auth tools with a redirect hint', () => {
       expect(LOKKA_AUTH_MUTATING_TOOLS).toEqual(
         expect.arrayContaining(['lokka-consent-permissions', 'add-graph-permission', 'set-access-token'])

--- a/src/tests/unit/SdkMcpConnection.test.ts
+++ b/src/tests/unit/SdkMcpConnection.test.ts
@@ -40,7 +40,7 @@ import { SdkMcpConnection } from '../../mcp/clients/SdkMcpConnection';
 
 const baseOpts = {
   command: 'npx',
-  args: ['-y', '@merill/lokka@2.0.0'],
+  args: ['-y', '@merill/lokka@2.1.2'],
   env: { TENANT_ID: 't', CLIENT_ID: 'c', USE_CLIENT_TOKEN: 'true', ACCESS_TOKEN: 'tok' },
   clientInfo: { name: 'EntraPulseLite', version: '1.3.0' },
   capabilities: {},

--- a/src/tests/unit/uiResource.test.ts
+++ b/src/tests/unit/uiResource.test.ts
@@ -13,6 +13,13 @@ describe('resolveUiResourceUri', () => {
     expect(resolveUiResourceUri('open-lokka-help', result)).toBe('ui://lokka/help.html');
   });
 
+  it('resolves the settings and guardrails apps from their _meta.ui.resourceUri', () => {
+    const settings = { _meta: { ui: { resourceUri: 'ui://lokka/settings.html' } }, structuredContent: { lokkaApp: 'settings' } };
+    expect(resolveUiResourceUri('open-lokka-settings', settings)).toBe('ui://lokka/settings.html');
+    const guardrails = { _meta: { ui: { resourceUri: 'ui://lokka/guardrails.html' } }, structuredContent: { lokkaApp: 'guardrails' } };
+    expect(resolveUiResourceUri('open-lokka-guardrails', guardrails)).toBe('ui://lokka/guardrails.html');
+  });
+
   it('prefers nested over flat when both present', () => {
     const result = { _meta: { ui: { resourceUri: 'ui://nested' }, 'ui/resourceUri': 'ui://flat' } };
     expect(resolveUiResourceUri('x', result)).toBe('ui://nested');
@@ -67,6 +74,18 @@ describe('detectLokkaAppIntent', () => {
     }
   });
 
+  it('routes settings intents to open-lokka-settings', () => {
+    for (const q of ['lokka settings', 'manage lokka', 'lokka configuration', 'open the lokka settings']) {
+      expect(detectLokkaAppIntent(q)).toEqual({ tool: 'open-lokka-settings', resourceUri: 'ui://lokka/settings.html' });
+    }
+  });
+
+  it('routes guardrails intents to open-lokka-guardrails', () => {
+    for (const q of ['guardrails', 'lokka guardrails', 'manage my guardrails', 'limit what the ai can do']) {
+      expect(detectLokkaAppIntent(q)).toEqual({ tool: 'open-lokka-guardrails', resourceUri: 'ui://lokka/guardrails.html' });
+    }
+  });
+
   it('does NOT hijack ordinary Graph queries', () => {
     for (const q of ['list all users', 'show my group memberships', 'how many guest accounts are there', 'get the CEO of the company', '']) {
       expect(detectLokkaAppIntent(q)).toBeNull();
@@ -75,12 +94,14 @@ describe('detectLokkaAppIntent', () => {
 });
 
 describe('Lokka exposed-tools allowlist', () => {
-  it('exposes the four open-* UI app tools alongside the core tools', () => {
+  it('exposes the six open-* UI app tools alongside the core tools', () => {
     expect(LOKKA_UI_APP_TOOLS).toEqual([
       'open-graph-explorer',
       'open-lokka-connections',
       'open-lokka-permissions',
       'open-lokka-help',
+      'open-lokka-settings',
+      'open-lokka-guardrails',
     ]);
     for (const t of LOKKA_UI_APP_TOOLS) {
       expect(LOKKA_EXPOSED_TOOLS).toContain(t);


### PR DESCRIPTION
## Summary

Rolls up work from v1.3.2 through v1.3.4 plus a CI fix that unblocked the multi-platform release builds.

- **CI (v1.3.4 hotfix):** Bump all electron-builder release workflows from Node 18 to Node 20. `electron-builder` 26.7.0's bundled `@electron/rebuild` uses `import.meta.dirname` (Node 20.11+) when forking the native rebuild worker; on Node 18 that is `undefined`, so `path.resolve` threw `paths[0] must be of type string` during the `keytar` prepare step, failing every platform build. Verified: the Multi-Platform Signed Release workflow now succeeds on this branch and produced a tag.
- **v1.3.4:** Support Lokka 2.1.2's Settings and Guardrails MCP apps.
- **v1.3.3:** Lokka Connection Manager multi-tenant support (+ review fixes).
- **v1.3.2:** Repair "Check for Updates"; show benign update states as info instead of a red error toast; gracefully fall back to an unsigned Windows build when signing fails.

## Verification

- Multi-Platform Signed Release workflow ran green on this branch and generated a new tag.
- Existing Jest suites updated for the multi-tenant / Lokka changes.